### PR TITLE
Apply min and max limits to NumberInput

### DIFF
--- a/input/NumberInput.qml
+++ b/input/NumberInput.qml
@@ -12,11 +12,24 @@ BaseInput {
 	onMinChanged: { this.element.setProperty('min', value) }
 	onMaxChanged: { this.element.setProperty('max', value) }
 	onStepChanged: { this.element.setProperty('step', value) }
-	onValueChanged: { this._setValue(value) }
+    onValueChanged: {
+        this.value = this._setValueWithLimits(value);
+    }
+
+    /// @private - sets element native value while applying min/max limits. if called externally, onValueChanged will not fire
+    function _setValueWithLimits(_value) {
+        if(_value > this.max) {
+            _value = this.max;
+        } else if(_value < this.min) {
+            _value = this.min;
+        }
+        this._setValue(_value);
+        return(_value);
+    }
 
 	constructor: {
 		this.element.on("input", function() {
-			this.value = this._getValue()
-		}.bind(this))
+            this.value = this._setValueWithLimits(this._getValue());
+        }.bind(this))
 	}
 }


### PR DESCRIPTION
 Previously the min and max limits were only applied if the up/down arrow selectors were used
 this applies min/max to input or programatically setting the 'value' property
 setting the value property to an out of range value will cause the onValueChanged signal to fire twice,
 once for the out of rang and once when automatically set back to the max/min