### PR TITLE
Rewrite the WebSocketClient to be a thin wrapper around WebSockets

### DIFF
--- a/web/websocket/WebSocketClient.qml
+++ b/web/websocket/WebSocketClient.qml
@@ -1,47 +1,77 @@
+/// Wrapper for a WebSocket
+/// The comments are copied or inspired by https://developer.mozilla.org/en-US/docs/Web/API/WebSocket
 Object {
-	signal error;
-	signal closed;
-	signal message;
-	property bool connected;
-	property string ip;
-	property string port;
-	property string host: "ws://" + ip + ":" + port;
+	/// The URL to which to connect; this should be the URL to which the WebSocket server will respond.
+	/// The url needs to start with either 'ws://' or 'wss://'
+	property string url;
 
+	/// 0 CONNECTING  Socket has been created. The connection is not yet open.
+	/// 1 OPEN        The connection is open and ready to communicate.
+	/// 2 CLOSING     The connection is in the process of closing.
+	/// 3 CLOSED      The connection is closed or couldn't be opened.
+	property enum state { Connecting, Open, Closing, Closed }: Closed;
+
+	/// Emitted when a message is received from the server.
+	signal message;
+	/// Emitted when the state changes to 1 (Open); this indicates that the connection is ready to send and receive data.
+	signal opened;
+	/// Emitted when the socket was closed, the event has at least the following three members code, reason and wasClean
+	signal closed;
+	/// Emitted when an error occurs on the WebSocket.
+	signal error;
+
+	/// Method enqueues the specified data to be transmitted to the server over the WebSocket connection.
 	send(msg): {
-		log("send:", this.connected, "socket", this._socket)
-		if (this.connected)
+		if (this.state == this.Open)
 			this._socket.send(msg)
 	}
 
+	/// Initiate connect to the provided url
 	connect: {
-		if (!this.ip || !this.port) {
-			log("Failed to connect port:", this.port, "ip:", this.ip)
+		if (!this.url) {
+			this.error("url not set")
 			return
 		}
 
-		log("Create socket for host:", this.host)
-		var socket = new WebSocket(this.host)
-		log("socket created", socket)
-		var context = this._context
-		var self = this
+		try {
+			var socket = new WebSocket(this.url)
+			this._socket = socket
+			this.state = this.Connecting
 
-		socket.onopen = context.wrapNativeCallback(function() {
-			log("Sonnection opened")
-			self.connected = true
-		})
+			var context = this._context
+			var self = this
+			socket.onopen = context.wrapNativeCallback(function() {
+				self.state = self.Open
+				self.opened();
+			})
 
-		socket.onclose = context.wrapNativeCallback(function(event) {
-			log('Connection was closed. Code:', event.code, 'reason:', event.reason, "wasClean:", event.wasClean)
-			self.connected = false
-		})
+			socket.onclose = context.wrapNativeCallback(function(event) {
+				self.state = self.Closed
+				self.closed(event)
+			})
 
-		socket.onerror = context.wrapNativeCallback(function(error) {
-			log("Connection error:", error.message)
-		})
+			socket.onerror = context.wrapNativeCallback(function(error) {
+				self.error("error")
+			})
 
-		socket.onmessage = context.wrapNativeCallback(function(event) {
-			var data = JSON.parse(event.data)
-			self.message(data)
-		})
+			socket.onmessage = context.wrapNativeCallback(function(event) {
+				self.message(event.data)
+			})
+		} catch(e) {
+			this.error("connect error reason: " + e)
+		}
+	}
+
+	/// Closes the WebSocket connection or connection attempt, if any.
+	close: {
+		if(!this._socket)
+			return;
+		this.state = self.Closing
+		this._socket.close()
+	}
+
+	/// Returns the number of bytes of data that have been queued using calls to send() but not yet transmitted to the network.
+	bufferedAmount: {
+		return this._socket.bufferedAmount;
 	}
 }


### PR DESCRIPTION
It is mostly based on the WebSocket API.
It differs greatly from the Qt API (https://doc.qt.io/qt-5/qml-qtwebsockets-websocket.html).
I'm still unsure if we should directly provide connect/close or instead use a property to connect/close as the Qt API (called active).
Changing the API shouldn't be an issue since the old implementation was broken (this._socket was undefined).
The old API was inconsistent, send didn't call JSON.stringify() but onMessage called JSON.parse(), therefore I dropped it.