### PR TITLE
Fixed issue in BaseInput: Setting the element attribute to 'disabled=…

### DIFF
--- a/input/BaseInput.qml
+++ b/input/BaseInput.qml
@@ -61,7 +61,12 @@ Item {
 	}
 
 	onEnabledChanged: {
-		this.element.setAttribute('disabled', !value)
+		if(value) {
+			this.element.dom.removeAttribute('disabled');
+		}
+		else {
+			this.element.dom.setAttribute('disabled', true);
+		}
 	}
 
 	onAutocompleteChanged: {


### PR DESCRIPTION
…false' will still disable the item-- instead, the 'disabled' attribute should be removed altogether.